### PR TITLE
feat(frontend): add Basic/Advanced mode switch and implement advanced-rule UI & flow

### DIFF
--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -165,6 +165,56 @@ body {
 }
 
 
+
+.advanced-only.hidden {
+  display: none;
+}
+
+.outcome-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.outcome-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(54px, 1fr));
+  gap: 8px;
+}
+
+.outcome-chip {
+  min-height: 34px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: #cdd8f8;
+  background: rgba(255,255,255,0.03);
+}
+
+.outcome-chip.win {
+  border-color: rgba(55,214,122,0.7);
+  color: #9cf2ba;
+  background: rgba(55,214,122,0.12);
+}
+
+.outcome-chip.lose {
+  border-color: rgba(255,107,123,0.7);
+  color: #ffb8c1;
+  background: rgba(255,107,123,0.12);
+}
+
+.outcome-chip.draw {
+  border-color: rgba(249,189,89,0.7);
+  color: #ffd79a;
+  background: rgba(249,189,89,0.12);
+}
+
+.action-buttons {
+  display: flex;
+  gap: 8px;
+}
 .func-row-wrap {
   display: grid;
   gap: 6px;
@@ -463,7 +513,8 @@ th {
 
   .slots,
   .hand,
-  .func-row {
+  .func-row,
+  .outcome-row {
     grid-template-columns: repeat(5, minmax(48px, 1fr));
     gap: 6px;
   }
@@ -479,7 +530,8 @@ th {
 
   .action-row,
   .advanced-grid,
-  .effect-panel {
+  .effect-panel,
+  .action-buttons {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -56,6 +56,22 @@ body {
   color: var(--muted);
 }
 
+.mode-switch {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+}
+
+.button.mode {
+  background: #dbe6ff;
+  color: #294486;
+}
+
+.button.mode.active {
+  background: var(--primary);
+  color: #fff;
+}
+
 .battlefield {
   border: 1px solid var(--line);
   border-radius: 12px;
@@ -115,6 +131,39 @@ body {
   grid-template-columns: 1fr auto;
   gap: 10px;
   align-items: center;
+}
+
+.advanced-controls {
+  margin-top: 6px;
+  padding: 10px 12px;
+}
+
+.advanced-controls h3 {
+  margin: 0 0 8px;
+}
+
+.advanced-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.advanced-grid label {
+  display: block;
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+
+.advanced-grid select {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+.hidden {
+  display: none;
 }
 
 .hint {
@@ -240,6 +289,10 @@ th {
   }
 
   .action-row {
+    grid-template-columns: 1fr;
+  }
+
+  .advanced-grid {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -1,14 +1,17 @@
 :root {
-  --bg: #eef3fb;
-  --panel: #ffffff;
-  --line: #d4deef;
-  --text: #1f2536;
-  --muted: #69748d;
-  --primary: #2f6df6;
-  --primary-soft: #dbe6ff;
-  --win: #16a34a;
-  --lose: #dc2626;
-  --draw: #ca8a04;
+  --bg: #060b16;
+  --bg-2: #0f1a34;
+  --panel: rgba(19, 27, 50, 0.72);
+  --panel-solid: #131b32;
+  --line: rgba(146, 170, 236, 0.28);
+  --text: #e8eeff;
+  --muted: #a8b6da;
+  --primary: #6d8dff;
+  --primary-soft: rgba(109, 141, 255, 0.2);
+  --accent: #3ce0b4;
+  --win: #37d67a;
+  --lose: #ff6b7b;
+  --draw: #f9bd59;
 }
 
 * {
@@ -19,8 +22,11 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: "Noto Sans TC", Arial, sans-serif;
-  background: var(--bg);
   color: var(--text);
+  background:
+    radial-gradient(circle at 10% 10%, #243760 0%, transparent 40%),
+    radial-gradient(circle at 90% 15%, #163744 0%, transparent 35%),
+    linear-gradient(145deg, var(--bg) 0%, var(--bg-2) 55%, #111a2d 100%);
 }
 
 .layout {
@@ -28,53 +34,71 @@ body {
   margin: 12px auto;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 360px;
-  gap: 12px;
+  gap: 14px;
   align-items: start;
 }
 
 .panel {
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  box-shadow: 0 1px 6px rgba(20, 40, 80, 0.08);
+  border-radius: 16px;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 16px 40px rgba(5, 9, 20, 0.35);
 }
 
 .game-shell {
-  padding: 14px;
+  padding: 16px;
   min-height: calc(100vh - 24px);
   display: grid;
   grid-template-rows: auto 1fr auto auto;
-  gap: 10px;
+  gap: 12px;
+}
+
+.modern-hero {
+  background: linear-gradient(135deg, rgba(109, 141, 255, 0.16), rgba(60, 224, 180, 0.08));
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
 }
 
 .game-header h1 {
-  font-size: clamp(20px, 2.2vw, 30px);
-  margin: 0;
+  font-size: clamp(22px, 2.3vw, 32px);
+  margin: 4px 0 0;
 }
 
 .subtitle {
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   color: var(--muted);
 }
 
 .mode-switch {
-  margin-top: 10px;
+  margin-top: 12px;
   display: flex;
-  gap: 8px;
+  gap: 10px;
 }
 
 .button.mode {
   background: var(--primary-soft);
-  color: #294486;
+  color: #dce6ff;
+  border: 1px solid rgba(129, 155, 233, 0.45);
 }
 
 .button.mode.active {
-  background: var(--primary);
+  background: linear-gradient(135deg, #6d8dff, #5876ec);
   color: #fff;
+  box-shadow: 0 10px 20px rgba(93, 120, 237, 0.4);
 }
 
 .guide-strip {
-  margin-top: 10px;
+  margin-top: 12px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
@@ -83,31 +107,33 @@ body {
 .guide-step {
   border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 4px 10px;
-  font-size: 13px;
+  padding: 4px 11px;
+  font-size: 12px;
   color: var(--muted);
-  background: #f8faff;
+  background: rgba(255, 255, 255, 0.02);
 }
 
 .guide-step.active {
-  border-color: var(--primary);
-  color: var(--primary);
+  border-color: rgba(126, 153, 255, 0.8);
+  color: #d7e1ff;
   font-weight: 700;
+  background: rgba(126, 153, 255, 0.2);
 }
 
 .guide-step.done {
-  border-color: #9dd7b0;
-  color: #16823f;
-  background: #effcf4;
+  border-color: rgba(60, 224, 180, 0.6);
+  color: #9cf2da;
+  background: rgba(60, 224, 180, 0.15);
 }
 
 .battlefield {
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 12px;
+  border-radius: 16px;
+  padding: 14px;
   display: grid;
   grid-template-rows: auto auto auto auto auto auto;
-  gap: 8px;
+  gap: 10px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
 }
 
 .row-title {
@@ -131,8 +157,8 @@ body {
 .pill {
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: #f8faff;
-  color: #3a4a78;
+  background: rgba(255, 255, 255, 0.05);
+  color: #d4e1ff;
   padding: 4px 10px;
   font-size: 12px;
   white-space: nowrap;
@@ -147,8 +173,8 @@ body {
 
 .slot,
 .card {
-  min-height: 72px;
-  border-radius: 10px;
+  min-height: 74px;
+  border-radius: 12px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -156,19 +182,28 @@ body {
 }
 
 .slot {
-  border: 2px dashed #c8d5f7;
-  background: #f7f9ff;
+  border: 1px dashed rgba(168, 188, 245, 0.75);
+  background: rgba(255, 255, 255, 0.03);
+  color: #dbe6ff;
 }
 
 .card {
-  border: 1px solid #9aa7c7;
-  background: linear-gradient(145deg, #fff, #f2f6ff);
+  border: 1px solid rgba(153, 174, 235, 0.65);
+  background: linear-gradient(155deg, rgba(109, 141, 255, 0.35), rgba(85, 106, 170, 0.28));
+  color: #f4f7ff;
   font-size: clamp(24px, 3vw, 30px);
   cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(26, 39, 84, 0.45);
+  border-color: rgba(175, 197, 255, 0.95);
 }
 
 .card.dragging {
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 .action-row {
@@ -179,7 +214,8 @@ body {
 }
 
 .advanced-controls {
-  padding: 10px 12px;
+  padding: 12px;
+  background: linear-gradient(145deg, rgba(109, 141, 255, 0.14), rgba(60, 224, 180, 0.07));
 }
 
 .advanced-top {
@@ -209,13 +245,16 @@ body {
   display: block;
   font-size: 13px;
   margin-bottom: 4px;
+  color: #d9e3ff;
 }
 
 .advanced-grid select {
   width: 100%;
   border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 8px;
+  border-radius: 10px;
+  padding: 9px;
+  background: rgba(11, 20, 41, 0.88);
+  color: #e9efff;
 }
 
 .hidden {
@@ -228,9 +267,9 @@ body {
 }
 
 .button {
-  border: none;
-  border-radius: 8px;
-  background: var(--primary);
+  border: 1px solid rgba(121, 145, 224, 0.6);
+  border-radius: 10px;
+  background: linear-gradient(135deg, #6d8dff, #5b79ed);
   color: #fff;
   font-size: 15px;
   padding: 10px 16px;
@@ -252,11 +291,12 @@ body {
 
 .fold {
   padding: 10px 12px;
+  background: var(--panel-solid);
 }
 
 .fold summary {
   cursor: pointer;
-  font-size: 23px;
+  font-size: 21px;
   font-weight: 600;
   list-style: none;
 }
@@ -279,6 +319,8 @@ body {
 table {
   width: 100%;
   border-collapse: collapse;
+  overflow: hidden;
+  border-radius: 10px;
 }
 
 th,
@@ -290,7 +332,7 @@ td {
 }
 
 th {
-  background: #ecf1ff;
+  background: rgba(109, 141, 255, 0.22);
 }
 
 .final-result {

--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -292,6 +292,54 @@ body {
   color: #e9efff;
 }
 
+
+.effect-panel {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.effect-block {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(11, 20, 41, 0.45);
+}
+
+.effect-block h4 {
+  margin: 0 0 8px;
+}
+
+.effect-log {
+  margin: 0;
+  padding-left: 18px;
+  line-height: 1.6;
+  color: #d7e3ff;
+}
+
+.mini-label {
+  margin: 6px 0 5px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.mini-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 30px;
+}
+
+.mini-chip {
+  min-width: 28px;
+  text-align: center;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 9px;
+  background: rgba(109, 141, 255, 0.18);
+  font-weight: 700;
+}
 .hidden {
   display: none;
 }
@@ -430,7 +478,8 @@ th {
   }
 
   .action-row,
-  .advanced-grid {
+  .advanced-grid,
+  .effect-panel {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -164,6 +164,41 @@ body {
   white-space: nowrap;
 }
 
+
+.func-row-wrap {
+  display: grid;
+  gap: 6px;
+}
+
+.func-label {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.func-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(54px, 1fr));
+  gap: 8px;
+}
+
+.func-slot {
+  min-height: 40px;
+  border-radius: 10px;
+  border: 1px dashed rgba(168, 188, 245, 0.55);
+  background: rgba(255, 255, 255, 0.03);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: #dbe6ff;
+  font-size: 13px;
+}
+
+.func-slot.active {
+  border-style: solid;
+  border-color: rgba(60, 224, 180, 0.8);
+  background: rgba(60, 224, 180, 0.18);
+}
 .slots,
 .hand {
   display: grid;
@@ -236,7 +271,7 @@ body {
 
 .advanced-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr auto;
+  grid-template-columns: 1fr 1fr auto auto;
   gap: 10px;
   align-items: end;
 }
@@ -379,7 +414,8 @@ th {
   }
 
   .slots,
-  .hand {
+  .hand,
+  .func-row {
     grid-template-columns: repeat(5, minmax(48px, 1fr));
     gap: 6px;
   }
@@ -401,4 +437,10 @@ th {
   .button {
     width: 100%;
   }
+}
+
+.button.ghost {
+  background: transparent;
+  border-color: rgba(168, 188, 245, 0.6);
+  color: #d8e5ff;
 }

--- a/frontend/12345.css
+++ b/frontend/12345.css
@@ -5,6 +5,7 @@
   --text: #1f2536;
   --muted: #69748d;
   --primary: #2f6df6;
+  --primary-soft: #dbe6ff;
   --win: #16a34a;
   --lose: #dc2626;
   --draw: #ca8a04;
@@ -23,10 +24,10 @@ body {
 }
 
 .layout {
-  width: min(1280px, 96vw);
+  width: min(1360px, 96vw);
   margin: 12px auto;
   display: grid;
-  grid-template-columns: 1fr 320px;
+  grid-template-columns: minmax(0, 1fr) 360px;
   gap: 12px;
   align-items: start;
 }
@@ -42,12 +43,12 @@ body {
   padding: 14px;
   min-height: calc(100vh - 24px);
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto 1fr auto auto;
   gap: 10px;
 }
 
 .game-header h1 {
-  font-size: clamp(20px, 2.2vw, 32px);
+  font-size: clamp(20px, 2.2vw, 30px);
   margin: 0;
 }
 
@@ -63,7 +64,7 @@ body {
 }
 
 .button.mode {
-  background: #dbe6ff;
+  background: var(--primary-soft);
   color: #294486;
 }
 
@@ -72,25 +73,69 @@ body {
   color: #fff;
 }
 
+.guide-strip {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.guide-step {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 13px;
+  color: var(--muted);
+  background: #f8faff;
+}
+
+.guide-step.active {
+  border-color: var(--primary);
+  color: var(--primary);
+  font-weight: 700;
+}
+
+.guide-step.done {
+  border-color: #9dd7b0;
+  color: #16823f;
+  background: #effcf4;
+}
+
 .battlefield {
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 12px;
   display: grid;
   grid-template-rows: auto auto auto auto auto auto;
-  align-content: start;
   gap: 8px;
+}
+
+.row-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
 }
 
 .battlefield h2 {
   margin: 0;
-  font-size: 22px;
-  text-align: center;
+  font-size: 20px;
   font-weight: 700;
 }
 
 .mid-title {
+  text-align: center;
   margin-top: 2px;
+}
+
+.pill {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: #f8faff;
+  color: #3a4a78;
+  padding: 4px 10px;
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .slots,
@@ -134,12 +179,23 @@ body {
 }
 
 .advanced-controls {
-  margin-top: 6px;
   padding: 10px 12px;
 }
 
-.advanced-controls h3 {
-  margin: 0 0 8px;
+.advanced-top {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.advanced-top h3 {
+  margin: 0;
+}
+
+.advanced-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .advanced-grid {
@@ -181,6 +237,11 @@ body {
   cursor: pointer;
 }
 
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .side-panels {
   display: grid;
   gap: 10px;
@@ -195,8 +256,8 @@ body {
 
 .fold summary {
   cursor: pointer;
-  font-size: 28px;
-  font-weight: 500;
+  font-size: 23px;
+  font-weight: 600;
   list-style: none;
 }
 
@@ -208,7 +269,8 @@ body {
   margin-bottom: 8px;
 }
 
-.fold ol {
+.fold ol,
+.card-guide {
   margin: 0;
   padding-left: 18px;
   line-height: 1.7;
@@ -248,7 +310,7 @@ th {
   color: var(--draw);
 }
 
-@media (max-width: 980px) {
+@media (max-width: 1100px) {
   .layout {
     grid-template-columns: 1fr;
     margin: 8px auto 14px;
@@ -262,15 +324,16 @@ th {
     max-height: none;
     overflow: visible;
   }
-
-  .fold summary {
-    font-size: 22px;
-  }
 }
 
-@media (max-width: 620px) {
+@media (max-width: 680px) {
   .battlefield h2 {
     font-size: 18px;
+  }
+
+  .row-title {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .slots,
@@ -288,10 +351,7 @@ th {
     font-size: 22px;
   }
 
-  .action-row {
-    grid-template-columns: 1fr;
-  }
-
+  .action-row,
   .advanced-grid {
     grid-template-columns: 1fr;
   }

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -12,8 +12,12 @@
   <main class="layout">
     <section class="game-shell panel">
       <header class="game-header">
-        <h1>1-2-3-4-5 遊戲（基本規則）</h1>
-        <p class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+        <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
+        <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+        <div class="mode-switch" role="group" aria-label="模式切換">
+          <button id="mode-basic" class="button mode active" type="button">普通模式</button>
+          <button id="mode-advanced" class="button mode" type="button">進階模式</button>
+        </div>
       </header>
 
       <section class="battlefield">
@@ -31,12 +35,34 @@
         <p id="hint" class="hint">拖曳或點擊下方玩家卡牌開始出牌。</p>
         <button id="restart-btn" class="button" type="button">Restart</button>
       </footer>
+
+      <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
+        <h3>進階功能卡操作</h3>
+        <div class="advanced-grid">
+          <div>
+            <label for="player-card-select">玩家功能卡</label>
+            <select id="player-card-select"></select>
+          </div>
+          <div>
+            <label for="player-pos-select">放置位置</label>
+            <select id="player-pos-select">
+              <option value="1">位置 1</option>
+              <option value="2">位置 2</option>
+              <option value="3">位置 3</option>
+              <option value="4">位置 4</option>
+              <option value="5">位置 5</option>
+            </select>
+          </div>
+          <button id="resolve-advanced-btn" class="button" type="button">結算本大局</button>
+        </div>
+        <p id="advanced-status" class="hint"></p>
+      </section>
     </section>
 
     <aside class="side-panels">
       <details class="panel fold" open>
         <summary>遊戲方法與提示</summary>
-        <ol>
+        <ol id="rules-list">
           <li>每回合從玩家手牌出 1 張。</li>
           <li>共 5 回合，系統會顯示 WIN / LOSE / DRAW。</li>
           <li>按 Restart 可快速再開一局。</li>

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -35,11 +35,21 @@
         </div>
         <div id="cpu-area" class="slots"></div>
 
+        <div class="func-row-wrap">
+          <span class="func-label">電腦功能卡擺放</span>
+          <div id="cpu-func-row" class="func-row"></div>
+        </div>
+
         <h2 class="mid-title">出牌區</h2>
         <div id="player-area" class="slots drop-target" aria-label="玩家置牌區"></div>
 
         <h2>玩家手牌</h2>
         <div id="player-hand" class="hand"></div>
+
+        <div class="func-row-wrap">
+          <span class="func-label">玩家功能卡擺放</span>
+          <div id="player-func-row" class="func-row"></div>
+        </div>
       </section>
 
       <footer class="action-row">
@@ -72,7 +82,8 @@
               <option value="5">位置 5</option>
             </select>
           </div>
-          <button id="resolve-advanced-btn" class="button" type="button" disabled>結算本大局</button>
+          <button id="resolve-advanced-btn" class="button" type="button" disabled>執行功能卡效果</button>
+          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
         </div>
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -35,9 +35,16 @@
         </div>
         <div id="cpu-area" class="slots"></div>
 
-        <div class="func-row-wrap">
-          <span class="func-label">電腦功能卡擺放</span>
-          <div id="cpu-func-row" class="func-row"></div>
+        <div id="advanced-board-tools" class="advanced-only hidden">
+          <div class="func-row-wrap">
+            <span class="func-label">電腦功能卡擺放</span>
+            <div id="cpu-func-row" class="func-row"></div>
+          </div>
+
+          <div class="func-row-wrap">
+            <span class="func-label">玩家功能卡擺放</span>
+            <div id="player-func-row" class="func-row"></div>
+          </div>
         </div>
 
         <h2 class="mid-title">出牌區</h2>
@@ -46,15 +53,18 @@
         <h2>玩家手牌</h2>
         <div id="player-hand" class="hand"></div>
 
-        <div class="func-row-wrap">
-          <span class="func-label">玩家功能卡擺放</span>
-          <div id="player-func-row" class="func-row"></div>
+        <div class="outcome-wrap">
+          <span class="func-label">玩家每回合結果（主戰場直觀顯示）</span>
+          <div id="round-outcome-row" class="outcome-row"></div>
         </div>
       </section>
 
       <footer class="action-row">
         <p id="hint" class="hint">拖曳或點擊下方玩家卡牌開始出牌。</p>
-        <button id="restart-btn" class="button" type="button">Restart</button>
+        <div class="action-buttons">
+          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
+          <button id="restart-btn" class="button" type="button">Restart</button>
+        </div>
       </footer>
 
       <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
@@ -83,7 +93,6 @@
             </select>
           </div>
           <button id="resolve-advanced-btn" class="button" type="button" disabled>執行功能卡效果</button>
-          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
         </div>
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -11,7 +11,8 @@
 <body>
   <main class="layout">
     <section class="game-shell panel">
-      <header class="game-header">
+      <header class="game-header modern-hero">
+        <p class="eyebrow">ONE-TWO-FIVE • STRATEGY CARD GAME</p>
         <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
         <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
 

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -88,6 +88,24 @@
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>
         <p id="advanced-status" class="hint"></p>
+
+        <div class="effect-panel">
+          <div class="effect-block">
+            <h4>效果流程</h4>
+            <ol id="effect-log" class="effect-log">
+              <li>尚未執行功能卡效果。</li>
+            </ol>
+          </div>
+          <div class="effect-block">
+            <h4>盤面前後對照</h4>
+            <p class="mini-label">效果前（電腦 / 玩家）</p>
+            <div id="before-cpu" class="mini-row"></div>
+            <div id="before-player" class="mini-row"></div>
+            <p class="mini-label">效果後（電腦 / 玩家）</p>
+            <div id="after-cpu" class="mini-row"></div>
+            <div id="after-player" class="mini-row"></div>
+          </div>
+        </div>
       </section>
     </section>
 

--- a/frontend/12345.html
+++ b/frontend/12345.html
@@ -14,14 +14,24 @@
       <header class="game-header">
         <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
         <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+
         <div class="mode-switch" role="group" aria-label="模式切換">
           <button id="mode-basic" class="button mode active" type="button">普通模式</button>
           <button id="mode-advanced" class="button mode" type="button">進階模式</button>
         </div>
+
+        <div class="guide-strip" aria-live="polite">
+          <span id="step-choose-mode" class="guide-step active">1. 選模式</span>
+          <span id="step-play-five" class="guide-step">2. 出完 5 張牌</span>
+          <span id="step-resolve-card" class="guide-step">3.（進階）結算功能卡</span>
+        </div>
       </header>
 
       <section class="battlefield">
-        <h2>電腦手牌</h2>
+        <div class="row-title">
+          <h2>電腦手牌</h2>
+          <span id="round-progress" class="pill">回合 0 / 5</span>
+        </div>
         <div id="cpu-area" class="slots"></div>
 
         <h2 class="mid-title">出牌區</h2>
@@ -37,10 +47,18 @@
       </footer>
 
       <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
-        <h3>進階功能卡操作</h3>
+        <div class="advanced-top">
+          <h3>進階功能卡結算</h3>
+          <div class="advanced-stats">
+            <span id="major-round-pill" class="pill">大局 1 / 3+</span>
+            <span id="major-score-pill" class="pill">大局比數 玩家 0 : 0 電腦</span>
+            <span id="minor-score-pill" class="pill">小分 玩家 0 : 0 電腦</span>
+          </div>
+        </div>
+
         <div class="advanced-grid">
           <div>
-            <label for="player-card-select">玩家功能卡</label>
+            <label for="player-card-select">玩家功能卡（每張整場僅一次）</label>
             <select id="player-card-select"></select>
           </div>
           <div>
@@ -53,8 +71,10 @@
               <option value="5">位置 5</option>
             </select>
           </div>
-          <button id="resolve-advanced-btn" class="button" type="button">結算本大局</button>
+          <button id="resolve-advanced-btn" class="button" type="button" disabled>結算本大局</button>
         </div>
+
+        <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>
         <p id="advanced-status" class="hint"></p>
       </section>
     </section>
@@ -67,6 +87,17 @@
           <li>共 5 回合，系統會顯示 WIN / LOSE / DRAW。</li>
           <li>按 Restart 可快速再開一局。</li>
         </ol>
+      </details>
+
+      <details class="panel fold" open>
+        <summary>功能卡速查（進階）</summary>
+        <ul class="card-guide">
+          <li><strong>J</strong>：指定位置與左邊交換（位置1會和位置5交換）</li>
+          <li><strong>Q</strong>：指定位置與右邊交換（位置5會和位置1交換）</li>
+          <li><strong>K</strong>：指定位置與對手同位置交換</li>
+          <li><strong>JOKER</strong>：雙方整個盤面互換</li>
+        </ul>
+        <p class="hint">觸發順序：J/Q → K → JOKER（玩家先觸發）</p>
       </details>
 
       <details class="panel fold" open>

--- a/frontend/12345.js
+++ b/frontend/12345.js
@@ -5,11 +5,6 @@ const MODE = {
 };
 const CARD_LABELS = ["J", "Q", "K", "JK"];
 
-const integrations = {
-  onRoundComplete: (_payload) => {},
-  onMatchComplete: (_payload) => {},
-};
-
 const state = {
   mode: MODE.BASIC,
   cpuDeck: [],
@@ -38,13 +33,24 @@ const hint = document.getElementById("hint");
 const gameTitle = document.getElementById("game-title");
 const gameSubtitle = document.getElementById("game-subtitle");
 const rulesList = document.getElementById("rules-list");
+const roundProgress = document.getElementById("round-progress");
+
 const advancedControls = document.getElementById("advanced-controls");
 const advancedStatus = document.getElementById("advanced-status");
+const cardsLeft = document.getElementById("cards-left");
+const majorRoundPill = document.getElementById("major-round-pill");
+const majorScorePill = document.getElementById("major-score-pill");
+const minorScorePill = document.getElementById("minor-score-pill");
 const playerCardSelect = document.getElementById("player-card-select");
 const playerPosSelect = document.getElementById("player-pos-select");
 const resolveAdvancedBtn = document.getElementById("resolve-advanced-btn");
+
 const modeBasicBtn = document.getElementById("mode-basic");
 const modeAdvancedBtn = document.getElementById("mode-advanced");
+
+const stepChooseMode = document.getElementById("step-choose-mode");
+const stepPlayFive = document.getElementById("step-play-five");
+const stepResolveCard = document.getElementById("step-resolve-card");
 
 const shuffle = (list) => {
   const arr = [...list];
@@ -100,6 +106,27 @@ const buildSlots = () => {
   }
 };
 
+const setStepState = (el, { active = false, done = false }) => {
+  el.classList.toggle("active", active);
+  el.classList.toggle("done", done);
+};
+
+const updateGuide = () => {
+  const finishedFive = state.playerHistory.length === TOTAL_ROUNDS;
+  setStepState(stepChooseMode, { active: false, done: true });
+  setStepState(stepPlayFive, { active: !finishedFive, done: finishedFive });
+
+  if (state.mode === MODE.BASIC) {
+    setStepState(stepResolveCard, { active: false, done: true });
+  } else {
+    setStepState(stepResolveCard, { active: finishedFive, done: !finishedFive });
+  }
+};
+
+const updateRoundProgress = () => {
+  roundProgress.textContent = `回合 ${state.playerHistory.length} / ${TOTAL_ROUNDS}`;
+};
+
 const updateScoreboardView = () => {
   ["win", "lose", "draw"].forEach((result) => {
     document.getElementById(`cpu-${result}`).textContent = state.scoreboard.cpu[result];
@@ -151,6 +178,8 @@ const resetRound = () => {
   state.playerHistory = [];
   buildSlots();
   renderPlayerHand();
+  updateRoundProgress();
+  updateGuide();
 };
 
 const renderAdvancedCardOptions = () => {
@@ -161,20 +190,92 @@ const renderAdvancedCardOptions = () => {
     option.textContent = card === "JK" ? "JOKER" : card;
     playerCardSelect.appendChild(option);
   });
+
+  resolveAdvancedBtn.disabled = state.playerHistory.length !== TOTAL_ROUNDS || state.advanced.playerCards.length === 0;
+};
+
+const updateAdvancedDashboard = () => {
+  const major = state.advanced.majorScore;
+  const minor = state.advanced.minorScore;
+
+  majorRoundPill.textContent = `大局 ${state.advanced.majorRound} / 3+`;
+  majorScorePill.textContent = `大局比數 玩家 ${major.player} : ${major.cpu} 電腦`;
+  minorScorePill.textContent = `小分 玩家 ${minor.player} : ${minor.cpu} 電腦`;
+
+  const label = state.advanced.playerCards.map((card) => (card === "JK" ? "JOKER" : card)).join(", ");
+  cardsLeft.textContent = `剩餘功能卡：${label || "（無）"}`;
+};
+
+const countBoardResult = (cpuBoard, playerBoard) => {
+  let playerWins = 0;
+  let cpuWins = 0;
+  let draws = 0;
+
+  for (let i = 0; i < TOTAL_ROUNDS; i += 1) {
+    const result = compareCards(cpuBoard[i], playerBoard[i]);
+    if (result === "WIN") playerWins += 1;
+    if (result === "LOSE") cpuWins += 1;
+    if (result === "DRAW") draws += 1;
+  }
+
+  return { playerWins, cpuWins, draws };
+};
+
+const finalizeAdvancedIfNeeded = () => {
+  const { majorScore, minorScore, majorRound } = state.advanced;
+  const doneByScore = majorScore.player >= 2 || majorScore.cpu >= 2;
+  const tieAfterThree = majorRound >= 3 && majorScore.player === majorScore.cpu;
+  const shouldContinue = !doneByScore && (majorRound < 3 || tieAfterThree) && majorRound < 4;
+
+  if (shouldContinue) return false;
+
+  if (majorScore.player > majorScore.cpu) {
+    finalResult.textContent = `進階模式結束：玩家勝利（大局 ${majorScore.player}:${majorScore.cpu}）`;
+    finalResult.className = "final-result win";
+    state.scoreboard.player.win += 1;
+    state.scoreboard.cpu.lose += 1;
+  } else if (majorScore.player < majorScore.cpu) {
+    finalResult.textContent = `進階模式結束：電腦勝利（大局 ${majorScore.cpu}:${majorScore.player}）`;
+    finalResult.className = "final-result lose";
+    state.scoreboard.player.lose += 1;
+    state.scoreboard.cpu.win += 1;
+  } else if (minorScore.player > minorScore.cpu) {
+    finalResult.textContent = `進階模式結束：玩家以小分勝（${minorScore.player}:${minorScore.cpu}）`;
+    finalResult.className = "final-result win";
+    state.scoreboard.player.win += 1;
+    state.scoreboard.cpu.lose += 1;
+  } else if (minorScore.player < minorScore.cpu) {
+    finalResult.textContent = `進階模式結束：電腦以小分勝（${minorScore.cpu}:${minorScore.player}）`;
+    finalResult.className = "final-result lose";
+    state.scoreboard.player.lose += 1;
+    state.scoreboard.cpu.win += 1;
+  } else {
+    finalResult.textContent = "進階模式結束：完全平手";
+    finalResult.className = "final-result draw";
+    state.scoreboard.player.draw += 1;
+    state.scoreboard.cpu.draw += 1;
+  }
+
+  hint.textContent = "本局已完成，點擊 Restart 可重新開始。";
+  updateScoreboardView();
+  resolveAdvancedBtn.disabled = true;
+  return true;
 };
 
 const settleAdvancedMajorRound = () => {
-  if (state.playerHistory.length < TOTAL_ROUNDS) return;
+  if (state.playerHistory.length < TOTAL_ROUNDS || state.advanced.playerCards.length === 0) return;
+
   const playerCard = playerCardSelect.value;
   const playerPos = Number(playerPosSelect.value);
   if (!state.advanced.playerCards.includes(playerCard)) return;
 
   const cpuCard = state.advanced.cpuCards[Math.floor(Math.random() * state.advanced.cpuCards.length)];
-  const cpuPos = Math.floor(Math.random() * 5) + 1;
+  const cpuPos = Math.floor(Math.random() * TOTAL_ROUNDS) + 1;
 
   const playerBoard = [...state.playerHistory];
   const cpuBoard = [...state.cpuHistory];
 
+  // 觸發順序：J/Q -> K -> JOKER（玩家先觸發）
   if (playerCard === "J" || playerCard === "Q") applyJQ(playerBoard, playerCard, playerPos);
   if (cpuCard === "J" || cpuCard === "Q") applyJQ(cpuBoard, cpuCard, cpuPos);
   if (playerCard === "K") applyK(playerBoard, cpuBoard, playerPos);
@@ -182,16 +283,7 @@ const settleAdvancedMajorRound = () => {
   if (playerCard === "JK") applyJoker(playerBoard, cpuBoard);
   if (cpuCard === "JK") applyJoker(playerBoard, cpuBoard);
 
-  let playerWins = 0;
-  let cpuWins = 0;
-  let draws = 0;
-  for (let i = 0; i < 5; i += 1) {
-    const result = compareCards(cpuBoard[i], playerBoard[i]);
-    if (result === "WIN") playerWins += 1;
-    if (result === "LOSE") cpuWins += 1;
-    if (result === "DRAW") draws += 1;
-  }
-
+  const { playerWins, cpuWins, draws } = countBoardResult(cpuBoard, playerBoard);
   state.advanced.minorScore.player += playerWins;
   state.advanced.minorScore.cpu += cpuWins;
   state.advanced.minorScore.draw += draws;
@@ -200,73 +292,42 @@ const settleAdvancedMajorRound = () => {
   else if (playerWins < cpuWins) state.advanced.majorScore.cpu += 1;
   else state.advanced.majorScore.draw += 1;
 
-  state.advanced.playerCards = state.advanced.playerCards.filter((c) => c !== playerCard);
-  state.advanced.cpuCards = state.advanced.cpuCards.filter((c) => c !== cpuCard);
+  state.advanced.playerCards = state.advanced.playerCards.filter((card) => card !== playerCard);
+  state.advanced.cpuCards = state.advanced.cpuCards.filter((card) => card !== cpuCard);
 
-  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局：玩家 ${playerCard}(${playerPos}) / 電腦 ${cpuCard}(${cpuPos})，小局 ${playerWins}:${cpuWins}`;
+  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局結算：玩家 ${playerCard === "JK" ? "JOKER" : playerCard}(${playerPos})、電腦 ${cpuCard === "JK" ? "JOKER" : cpuCard}(${cpuPos})；小局 ${playerWins}:${cpuWins}（和局 ${draws}）`;
 
-  const isAfterThird = state.advanced.majorRound >= 3;
-  const major = state.advanced.majorScore;
-  const doneByScore = major.player >= 2 || major.cpu >= 2;
-  const tieNeedFourth = isAfterThird && major.player === major.cpu;
+  updateAdvancedDashboard();
+  updateGuide();
 
-  if (doneByScore || (isAfterThird && !tieNeedFourth) || state.advanced.majorRound === 4) {
-    if (major.player > major.cpu) {
-      finalResult.textContent = `進階模式結束：玩家勝利（大局 ${major.player}:${major.cpu}）`;
-      finalResult.className = "final-result win";
-      state.scoreboard.player.win += 1;
-      state.scoreboard.cpu.lose += 1;
-    } else if (major.player < major.cpu) {
-      finalResult.textContent = `進階模式結束：電腦勝利（大局 ${major.cpu}:${major.player}）`;
-      finalResult.className = "final-result lose";
-      state.scoreboard.player.lose += 1;
-      state.scoreboard.cpu.win += 1;
-    } else if (state.advanced.minorScore.player > state.advanced.minorScore.cpu) {
-      finalResult.textContent = `進階模式結束：玩家以小分勝（${state.advanced.minorScore.player}:${state.advanced.minorScore.cpu}）`;
-      finalResult.className = "final-result win";
-      state.scoreboard.player.win += 1;
-      state.scoreboard.cpu.lose += 1;
-    } else if (state.advanced.minorScore.player < state.advanced.minorScore.cpu) {
-      finalResult.textContent = `進階模式結束：電腦以小分勝（${state.advanced.minorScore.cpu}:${state.advanced.minorScore.player}）`;
-      finalResult.className = "final-result lose";
-      state.scoreboard.player.lose += 1;
-      state.scoreboard.cpu.win += 1;
-    } else {
-      finalResult.textContent = "進階模式結束：完全平手";
-      finalResult.className = "final-result draw";
-      state.scoreboard.player.draw += 1;
-      state.scoreboard.cpu.draw += 1;
-    }
-    hint.textContent = "本局已完成，點擊 Restart 開始下一局。";
-    updateScoreboardView();
-    integrations.onMatchComplete({ ...state.advanced });
-    return;
-  }
+  const finished = finalizeAdvancedIfNeeded();
+  if (finished) return;
 
   state.advanced.majorRound += 1;
-  hint.textContent = `進入第 ${state.advanced.majorRound} 大局，請完成 5 回合出牌。`;
-  finalResult.textContent = `進階進行中：大局 玩家 ${major.player} : 電腦 ${major.cpu}`;
+  hint.textContent = `進入第 ${state.advanced.majorRound} 大局：請先打完 5 回合再結算功能卡。`;
+  finalResult.textContent = `進階進行中：大局 玩家 ${state.advanced.majorScore.player} : 電腦 ${state.advanced.majorScore.cpu}`;
   finalResult.className = "final-result";
+
   resetRound();
   renderAdvancedCardOptions();
+  updateAdvancedDashboard();
 };
 
 const finalizeBasicGame = () => {
-  const wins = state.playerHistory.filter((_, i) => compareCards(state.cpuHistory[i], state.playerHistory[i]) === "WIN").length;
-  const loses = state.playerHistory.filter((_, i) => compareCards(state.cpuHistory[i], state.playerHistory[i]) === "LOSE").length;
+  const { playerWins, cpuWins } = countBoardResult(state.cpuHistory, state.playerHistory);
 
-  if (wins > loses) {
-    finalResult.textContent = `本局結束：玩家勝利（${wins}:${loses}）`;
+  if (playerWins > cpuWins) {
+    finalResult.textContent = `本局結束：玩家勝利（${playerWins}:${cpuWins}）`;
     finalResult.className = "final-result win";
     state.scoreboard.player.win += 1;
     state.scoreboard.cpu.lose += 1;
-  } else if (wins < loses) {
-    finalResult.textContent = `本局結束：電腦勝利（${loses}:${wins}）`;
+  } else if (playerWins < cpuWins) {
+    finalResult.textContent = `本局結束：電腦勝利（${cpuWins}:${playerWins}）`;
     finalResult.className = "final-result lose";
     state.scoreboard.player.lose += 1;
     state.scoreboard.cpu.win += 1;
   } else {
-    finalResult.textContent = `本局結束：平手（${wins}:${loses}）`;
+    finalResult.textContent = `本局結束：平手（${playerWins}:${cpuWins}）`;
     finalResult.className = "final-result draw";
     state.scoreboard.player.draw += 1;
     state.scoreboard.cpu.draw += 1;
@@ -274,21 +335,13 @@ const finalizeBasicGame = () => {
 
   hint.textContent = "本局已完成，點擊 Restart 開始下一局。";
   updateScoreboardView();
-
-  integrations.onMatchComplete({
-    cpuHistory: [...state.cpuHistory],
-    playerHistory: [...state.playerHistory],
-    scoreboard: JSON.parse(JSON.stringify(state.scoreboard)),
-  });
 };
 
 const playRound = (playerValue) => {
-  if (!state.playerDeck.includes(playerValue) || state.playerHistory.length >= TOTAL_ROUNDS) {
-    return;
-  }
+  if (!state.playerDeck.includes(playerValue) || state.playerHistory.length >= TOTAL_ROUNDS) return;
 
-  const cpuValue = state.cpuDeck[state.playerHistory.length];
   const roundIndex = state.playerHistory.length;
+  const cpuValue = state.cpuDeck[roundIndex];
 
   state.playerHistory.push(playerValue);
   state.cpuHistory.push(cpuValue);
@@ -300,20 +353,16 @@ const playRound = (playerValue) => {
   const roundResult = compareCards(cpuValue, playerValue);
   renderRoundRow(state.advanced.majorRound, roundIndex, cpuValue, playerValue, roundResult);
 
-  integrations.onRoundComplete({
-    round: roundIndex + 1,
-    cpu: cpuValue,
-    player: playerValue,
-    result: roundResult,
-  });
-
   renderPlayerHand();
+  updateRoundProgress();
+  updateGuide();
 
   if (state.playerHistory.length === TOTAL_ROUNDS) {
     if (state.mode === MODE.BASIC) {
       finalizeBasicGame();
     } else {
-      hint.textContent = "已完成 5 回合，請選擇功能卡與位置後按下「結算本大局」。";
+      hint.textContent = "5 回合完成！請選擇功能卡與位置，按「結算本大局」。";
+      resolveAdvancedBtn.disabled = false;
     }
   } else {
     hint.textContent = `已完成第 ${state.playerHistory.length} 回合，請繼續出牌。`;
@@ -331,9 +380,10 @@ const resetMatch = () => {
     state.advanced.minorScore = { cpu: 0, player: 0, draw: 0 };
     state.advanced.cpuCards = [...CARD_LABELS];
     state.advanced.playerCards = [...CARD_LABELS];
+    advancedStatus.textContent = "進階模式開始：每大局完成 5 回合後，再選 1 張功能卡結算。";
+    hint.textContent = "進階模式：先完成第 1 大局的 5 回合。";
     renderAdvancedCardOptions();
-    advancedStatus.textContent = "每大局可選 1 張功能卡，四張卡整場各只能用一次。";
-    hint.textContent = "進階模式：先完成第 1 大局的 5 回合，再結算功能卡。";
+    updateAdvancedDashboard();
   } else {
     hint.textContent = "拖曳或點擊下方玩家卡牌開始出牌。";
     advancedStatus.textContent = "";
@@ -345,17 +395,18 @@ const resetMatch = () => {
 const setMode = (mode) => {
   state.mode = mode;
   const isAdvanced = mode === MODE.ADVANCED;
+
   modeBasicBtn.classList.toggle("active", !isAdvanced);
   modeAdvancedBtn.classList.toggle("active", isAdvanced);
   advancedControls.classList.toggle("hidden", !isAdvanced);
 
   if (isAdvanced) {
     gameTitle.textContent = "1-2-3-4-5 遊戲（進階規則）";
-    gameSubtitle.innerHTML = "三大局制，含 <strong>J / Q / K / JOKER</strong> 功能卡；同分可比小分。";
+    gameSubtitle.innerHTML = "三大局制，含 <strong>J / Q / K / JOKER</strong> 功能卡，平手可比小分。";
     rulesList.innerHTML = `
       <li>每大局先進行 5 回合出牌（不可重複）。</li>
-      <li>再選 1 張功能卡與位置，依序觸發後結算大局。</li>
-      <li>共三大局；若同分可加開第四局並比較小分。</li>
+      <li>雙方各出 1 張功能卡並選位置，依序觸發後結算。</li>
+      <li>先到 2 勝直接獲勝；三大局同分可加開第四局，再比小分。</li>
     `;
   } else {
     gameTitle.textContent = "1-2-3-4-5 遊戲（基本規則）";

--- a/frontend/12345.js
+++ b/frontend/12345.js
@@ -49,6 +49,11 @@ const playerCardSelect = document.getElementById("player-card-select");
 const playerPosSelect = document.getElementById("player-pos-select");
 const resolveAdvancedBtn = document.getElementById("resolve-advanced-btn");
 const nextMajorBtn = document.getElementById("next-major-btn");
+const effectLog = document.getElementById("effect-log");
+const beforeCpu = document.getElementById("before-cpu");
+const beforePlayer = document.getElementById("before-player");
+const afterCpu = document.getElementById("after-cpu");
+const afterPlayer = document.getElementById("after-player");
 
 const modeBasicBtn = document.getElementById("mode-basic");
 const modeAdvancedBtn = document.getElementById("mode-advanced");
@@ -145,6 +150,36 @@ const renderBoardToArea = (cpuBoard, playerBoard) => {
   }
 };
 
+const renderMiniRow = (el, arr) => {
+  el.innerHTML = "";
+  arr.forEach((n) => {
+    const chip = document.createElement("span");
+    chip.className = "mini-chip";
+    chip.textContent = n;
+    el.appendChild(chip);
+  });
+};
+
+const clearEffectPanel = () => {
+  effectLog.innerHTML = "<li>尚未執行功能卡效果。</li>";
+  [beforeCpu, beforePlayer, afterCpu, afterPlayer].forEach((el) => {
+    el.innerHTML = "";
+  });
+};
+
+const renderEffectPanel = ({ logs, beforeCpuBoard, beforePlayerBoard, afterCpuBoard, afterPlayerBoard }) => {
+  effectLog.innerHTML = "";
+  logs.forEach((msg) => {
+    const li = document.createElement("li");
+    li.textContent = msg;
+    effectLog.appendChild(li);
+  });
+  renderMiniRow(beforeCpu, beforeCpuBoard);
+  renderMiniRow(beforePlayer, beforePlayerBoard);
+  renderMiniRow(afterCpu, afterCpuBoard);
+  renderMiniRow(afterPlayer, afterPlayerBoard);
+};
+
 const setStepState = (el, { active = false, done = false }) => {
   el.classList.toggle("active", active);
   el.classList.toggle("done", done);
@@ -221,6 +256,7 @@ const resetRound = () => {
   state.advanced.awaitingNext = false;
   buildSlots();
   clearFunctionPlacement();
+  clearEffectPanel();
   renderPlayerHand();
   updateRoundProgress();
   updateGuide();
@@ -348,18 +384,41 @@ const settleAdvancedMajorRound = () => {
 
   const playerBoard = [...state.playerHistory];
   const cpuBoard = [...state.cpuHistory];
+  const beforePlayerBoard = [...playerBoard];
+  const beforeCpuBoard = [...cpuBoard];
+  const logs = [
+    `玩家將 ${cardText(playerCard)} 放在位置 ${playerPos}，電腦將 ${cardText(cpuCard)} 放在位置 ${cpuPos}。`,
+  ];
 
   renderFunctionPlacement(cpuCard, cpuPos, playerCard, playerPos);
 
-  // 觸發順序：J/Q -> K -> JOKER（玩家先觸發）
-  if (playerCard === "J" || playerCard === "Q") applyJQ(playerBoard, playerCard, playerPos);
-  if (cpuCard === "J" || cpuCard === "Q") applyJQ(cpuBoard, cpuCard, cpuPos);
-  if (playerCard === "K") applyK(playerBoard, cpuBoard, playerPos);
-  if (cpuCard === "K") applyK(playerBoard, cpuBoard, cpuPos);
-  if (playerCard === "JK") applyJoker(playerBoard, cpuBoard);
-  if (cpuCard === "JK") applyJoker(playerBoard, cpuBoard);
+  if (playerCard === "J" || playerCard === "Q") {
+    applyJQ(playerBoard, playerCard, playerPos);
+    logs.push(`玩家 ${cardText(playerCard)} 先觸發，玩家盤面調整完成。`);
+  }
+  if (cpuCard === "J" || cpuCard === "Q") {
+    applyJQ(cpuBoard, cpuCard, cpuPos);
+    logs.push(`電腦 ${cardText(cpuCard)} 觸發，電腦盤面調整完成。`);
+  }
+  if (playerCard === "K") {
+    applyK(playerBoard, cpuBoard, playerPos);
+    logs.push(`玩家 K 觸發，交換雙方位置 ${playerPos}。`);
+  }
+  if (cpuCard === "K") {
+    applyK(playerBoard, cpuBoard, cpuPos);
+    logs.push(`電腦 K 觸發，交換雙方位置 ${cpuPos}。`);
+  }
+  if (playerCard === "JK") {
+    applyJoker(playerBoard, cpuBoard);
+    logs.push("玩家 JOKER 觸發，雙方整體盤面互換。");
+  }
+  if (cpuCard === "JK") {
+    applyJoker(playerBoard, cpuBoard);
+    logs.push("電腦 JOKER 觸發，雙方整體盤面互換。");
+  }
 
   renderBoardToArea(cpuBoard, playerBoard);
+  renderEffectPanel({ logs, beforeCpuBoard, beforePlayerBoard, afterCpuBoard: cpuBoard, afterPlayerBoard: playerBoard });
 
   const { playerWins, cpuWins, draws } = countBoardResult(cpuBoard, playerBoard);
   state.advanced.minorScore.player += playerWins;
@@ -375,7 +434,7 @@ const settleAdvancedMajorRound = () => {
 
   state.advanced.awaitingNext = true;
 
-  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局：玩家 ${cardText(playerCard)} 放在 ${playerPos} 號、電腦 ${cardText(cpuCard)} 放在 ${cpuPos} 號。效果執行後小局 ${playerWins}:${cpuWins}（和局 ${draws}）。`;
+  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局：玩家 ${cardText(playerCard)}(${playerPos})、電腦 ${cardText(cpuCard)}(${cpuPos})。小局 ${playerWins}:${cpuWins}（和局 ${draws}）。`;
 
   if (playerWins > cpuWins) {
     finalResult.textContent = `第 ${state.advanced.majorRound} 大局結果：玩家勝 (${playerWins}:${cpuWins})`;
@@ -395,7 +454,7 @@ const settleAdvancedMajorRound = () => {
   if (advancedShouldEnd()) {
     finalizeAdvancedMatch();
   } else {
-    hint.textContent = "此大局結果已展示。請按「下一大局」繼續。";
+    hint.textContent = "此大局效果與結果已展示。請按「下一大局」繼續。";
     nextMajorBtn.classList.remove("hidden");
   }
 };
@@ -449,7 +508,7 @@ const playRound = (playerValue) => {
     if (state.mode === MODE.BASIC) {
       finalizeBasicGame();
     } else {
-      hint.textContent = "5 回合完成，請選擇功能卡與位置，執行效果並查看本大局結果。";
+      hint.textContent = "5 回合完成，請擺放功能卡並執行效果（會顯示前後盤面與流程）。";
       resolveAdvancedBtn.disabled = false;
     }
   } else {
@@ -471,7 +530,7 @@ const resetMatch = () => {
     state.advanced.playerCards = [...CARD_LABELS];
     state.advanced.awaitingNext = false;
     state.advanced.matchFinished = false;
-    advancedStatus.textContent = "進階模式開始：先完成 5 回合，再把功能卡擺放到指定位置並執行效果。";
+    advancedStatus.textContent = "進階模式：先完成 5 回合，再擺放功能卡；系統會逐步展示效果流程與前後盤面。";
     hint.textContent = "進階模式：先完成第 1 大局的 5 回合。";
     renderAdvancedCardOptions();
     updateAdvancedDashboard();
@@ -493,11 +552,11 @@ const setMode = (mode) => {
 
   if (isAdvanced) {
     gameTitle.textContent = "1-2-3-4-5 遊戲（進階規則）";
-    gameSubtitle.innerHTML = "可視化功能卡擺放：<strong>J / Q / K / JOKER</strong>，每大局執行後展示結果再決定是否進下一局。";
+    gameSubtitle.innerHTML = "可視化功能卡擺放：<strong>J / Q / K / JOKER</strong>，執行後會保留結果畫面，方便觀察策略。";
     rulesList.innerHTML = `
       <li>每大局先進行 5 回合出牌（不可重複）。</li>
       <li>雙方把功能卡擺放到指定位置，再執行效果。</li>
-      <li>執行後會留在當前畫面展示結果，按「下一大局」才繼續。</li>
+      <li>執行後會展示「效果流程 + 前後盤面」，按「下一大局」才繼續。</li>
     `;
   } else {
     gameTitle.textContent = "1-2-3-4-5 遊戲（基本規則）";

--- a/frontend/12345.js
+++ b/frontend/12345.js
@@ -21,11 +21,15 @@ const state = {
     minorScore: { cpu: 0, player: 0, draw: 0 },
     cpuCards: [...CARD_LABELS],
     playerCards: [...CARD_LABELS],
+    awaitingNext: false,
+    matchFinished: false,
   },
 };
 
 const cpuArea = document.getElementById("cpu-area");
 const playerArea = document.getElementById("player-area");
+const cpuFuncRow = document.getElementById("cpu-func-row");
+const playerFuncRow = document.getElementById("player-func-row");
 const playerHand = document.getElementById("player-hand");
 const roundTableBody = document.querySelector("#round-table tbody");
 const finalResult = document.getElementById("final-result");
@@ -44,6 +48,7 @@ const minorScorePill = document.getElementById("minor-score-pill");
 const playerCardSelect = document.getElementById("player-card-select");
 const playerPosSelect = document.getElementById("player-pos-select");
 const resolveAdvancedBtn = document.getElementById("resolve-advanced-btn");
+const nextMajorBtn = document.getElementById("next-major-btn");
 
 const modeBasicBtn = document.getElementById("mode-basic");
 const modeAdvancedBtn = document.getElementById("mode-advanced");
@@ -51,6 +56,8 @@ const modeAdvancedBtn = document.getElementById("mode-advanced");
 const stepChooseMode = document.getElementById("step-choose-mode");
 const stepPlayFive = document.getElementById("step-play-five");
 const stepResolveCard = document.getElementById("step-resolve-card");
+
+const cardText = (card) => (card === "JK" ? "JOKER" : card);
 
 const shuffle = (list) => {
   const arr = [...list];
@@ -91,10 +98,33 @@ const applyJoker = (playerDeck, cpuDeck) => {
   cpuDeck.splice(0, cpuDeck.length, ...playerCopy);
 };
 
-const createSlot = () => {
+const createSlot = (className = "slot") => {
   const slot = document.createElement("div");
-  slot.className = "slot";
+  slot.className = className;
   return slot;
+};
+
+const buildFunctionRow = () => {
+  cpuFuncRow.innerHTML = "";
+  playerFuncRow.innerHTML = "";
+  for (let i = 0; i < TOTAL_ROUNDS; i += 1) {
+    cpuFuncRow.appendChild(createSlot("func-slot"));
+    playerFuncRow.appendChild(createSlot("func-slot"));
+  }
+};
+
+const clearFunctionPlacement = () => {
+  buildFunctionRow();
+};
+
+const renderFunctionPlacement = (cpuCard, cpuPos, playerCard, playerPos) => {
+  clearFunctionPlacement();
+  const cpuSlots = cpuFuncRow.querySelectorAll(".func-slot");
+  const playerSlots = playerFuncRow.querySelectorAll(".func-slot");
+  cpuSlots[cpuPos - 1].textContent = cardText(cpuCard);
+  cpuSlots[cpuPos - 1].classList.add("active");
+  playerSlots[playerPos - 1].textContent = cardText(playerCard);
+  playerSlots[playerPos - 1].classList.add("active");
 };
 
 const buildSlots = () => {
@@ -103,6 +133,15 @@ const buildSlots = () => {
   for (let i = 0; i < TOTAL_ROUNDS; i += 1) {
     cpuArea.appendChild(createSlot());
     playerArea.appendChild(createSlot());
+  }
+};
+
+const renderBoardToArea = (cpuBoard, playerBoard) => {
+  const cpuSlots = cpuArea.querySelectorAll(".slot");
+  const playerSlots = playerArea.querySelectorAll(".slot");
+  for (let i = 0; i < TOTAL_ROUNDS; i += 1) {
+    cpuSlots[i].textContent = cpuBoard[i];
+    playerSlots[i].textContent = playerBoard[i];
   }
 };
 
@@ -119,7 +158,10 @@ const updateGuide = () => {
   if (state.mode === MODE.BASIC) {
     setStepState(stepResolveCard, { active: false, done: true });
   } else {
-    setStepState(stepResolveCard, { active: finishedFive, done: !finishedFive });
+    setStepState(stepResolveCard, {
+      active: finishedFive && !state.advanced.awaitingNext,
+      done: state.advanced.awaitingNext || !finishedFive,
+    });
   }
 };
 
@@ -176,7 +218,9 @@ const resetRound = () => {
   state.playerDeck = [1, 2, 3, 4, 5];
   state.cpuHistory = [];
   state.playerHistory = [];
+  state.advanced.awaitingNext = false;
   buildSlots();
+  clearFunctionPlacement();
   renderPlayerHand();
   updateRoundProgress();
   updateGuide();
@@ -187,11 +231,15 @@ const renderAdvancedCardOptions = () => {
   state.advanced.playerCards.forEach((card) => {
     const option = document.createElement("option");
     option.value = card;
-    option.textContent = card === "JK" ? "JOKER" : card;
+    option.textContent = cardText(card);
     playerCardSelect.appendChild(option);
   });
 
-  resolveAdvancedBtn.disabled = state.playerHistory.length !== TOTAL_ROUNDS || state.advanced.playerCards.length === 0;
+  resolveAdvancedBtn.disabled =
+    state.playerHistory.length !== TOTAL_ROUNDS ||
+    state.advanced.playerCards.length === 0 ||
+    state.advanced.awaitingNext ||
+    state.advanced.matchFinished;
 };
 
 const updateAdvancedDashboard = () => {
@@ -202,7 +250,7 @@ const updateAdvancedDashboard = () => {
   majorScorePill.textContent = `大局比數 玩家 ${major.player} : ${major.cpu} 電腦`;
   minorScorePill.textContent = `小分 玩家 ${minor.player} : ${minor.cpu} 電腦`;
 
-  const label = state.advanced.playerCards.map((card) => (card === "JK" ? "JOKER" : card)).join(", ");
+  const label = state.advanced.playerCards.map((card) => cardText(card)).join(", ");
   cardsLeft.textContent = `剩餘功能卡：${label || "（無）"}`;
 };
 
@@ -221,13 +269,16 @@ const countBoardResult = (cpuBoard, playerBoard) => {
   return { playerWins, cpuWins, draws };
 };
 
-const finalizeAdvancedIfNeeded = () => {
-  const { majorScore, minorScore, majorRound } = state.advanced;
+const advancedShouldEnd = () => {
+  const { majorScore, majorRound } = state.advanced;
   const doneByScore = majorScore.player >= 2 || majorScore.cpu >= 2;
   const tieAfterThree = majorRound >= 3 && majorScore.player === majorScore.cpu;
-  const shouldContinue = !doneByScore && (majorRound < 3 || tieAfterThree) && majorRound < 4;
+  return doneByScore || (majorRound >= 3 && !tieAfterThree) || majorRound === 4;
+};
 
-  if (shouldContinue) return false;
+const finalizeAdvancedMatch = () => {
+  const { majorScore, minorScore } = state.advanced;
+  state.advanced.matchFinished = true;
 
   if (majorScore.player > majorScore.cpu) {
     finalResult.textContent = `進階模式結束：玩家勝利（大局 ${majorScore.player}:${majorScore.cpu}）`;
@@ -256,14 +307,37 @@ const finalizeAdvancedIfNeeded = () => {
     state.scoreboard.cpu.draw += 1;
   }
 
-  hint.textContent = "本局已完成，點擊 Restart 可重新開始。";
-  updateScoreboardView();
+  hint.textContent = "本場進階對局已完成，可點 Restart 重開。";
+  nextMajorBtn.classList.add("hidden");
   resolveAdvancedBtn.disabled = true;
-  return true;
+  updateScoreboardView();
+};
+
+const startNextMajorRound = () => {
+  if (!state.advanced.awaitingNext || state.advanced.matchFinished) return;
+
+  state.advanced.majorRound += 1;
+  state.advanced.awaitingNext = false;
+
+  hint.textContent = `進入第 ${state.advanced.majorRound} 大局：請先打完 5 回合，再擺放功能卡。`;
+  finalResult.textContent = `進階進行中：大局 玩家 ${state.advanced.majorScore.player} : 電腦 ${state.advanced.majorScore.cpu}`;
+  finalResult.className = "final-result";
+
+  nextMajorBtn.classList.add("hidden");
+  resetRound();
+  renderAdvancedCardOptions();
+  updateAdvancedDashboard();
 };
 
 const settleAdvancedMajorRound = () => {
-  if (state.playerHistory.length < TOTAL_ROUNDS || state.advanced.playerCards.length === 0) return;
+  if (
+    state.playerHistory.length < TOTAL_ROUNDS ||
+    state.advanced.playerCards.length === 0 ||
+    state.advanced.awaitingNext ||
+    state.advanced.matchFinished
+  ) {
+    return;
+  }
 
   const playerCard = playerCardSelect.value;
   const playerPos = Number(playerPosSelect.value);
@@ -275,6 +349,8 @@ const settleAdvancedMajorRound = () => {
   const playerBoard = [...state.playerHistory];
   const cpuBoard = [...state.cpuHistory];
 
+  renderFunctionPlacement(cpuCard, cpuPos, playerCard, playerPos);
+
   // 觸發順序：J/Q -> K -> JOKER（玩家先觸發）
   if (playerCard === "J" || playerCard === "Q") applyJQ(playerBoard, playerCard, playerPos);
   if (cpuCard === "J" || cpuCard === "Q") applyJQ(cpuBoard, cpuCard, cpuPos);
@@ -282,6 +358,8 @@ const settleAdvancedMajorRound = () => {
   if (cpuCard === "K") applyK(playerBoard, cpuBoard, cpuPos);
   if (playerCard === "JK") applyJoker(playerBoard, cpuBoard);
   if (cpuCard === "JK") applyJoker(playerBoard, cpuBoard);
+
+  renderBoardToArea(cpuBoard, playerBoard);
 
   const { playerWins, cpuWins, draws } = countBoardResult(cpuBoard, playerBoard);
   state.advanced.minorScore.player += playerWins;
@@ -295,22 +373,31 @@ const settleAdvancedMajorRound = () => {
   state.advanced.playerCards = state.advanced.playerCards.filter((card) => card !== playerCard);
   state.advanced.cpuCards = state.advanced.cpuCards.filter((card) => card !== cpuCard);
 
-  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局結算：玩家 ${playerCard === "JK" ? "JOKER" : playerCard}(${playerPos})、電腦 ${cpuCard === "JK" ? "JOKER" : cpuCard}(${cpuPos})；小局 ${playerWins}:${cpuWins}（和局 ${draws}）`;
+  state.advanced.awaitingNext = true;
+
+  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局：玩家 ${cardText(playerCard)} 放在 ${playerPos} 號、電腦 ${cardText(cpuCard)} 放在 ${cpuPos} 號。效果執行後小局 ${playerWins}:${cpuWins}（和局 ${draws}）。`;
+
+  if (playerWins > cpuWins) {
+    finalResult.textContent = `第 ${state.advanced.majorRound} 大局結果：玩家勝 (${playerWins}:${cpuWins})`;
+    finalResult.className = "final-result win";
+  } else if (playerWins < cpuWins) {
+    finalResult.textContent = `第 ${state.advanced.majorRound} 大局結果：電腦勝 (${cpuWins}:${playerWins})`;
+    finalResult.className = "final-result lose";
+  } else {
+    finalResult.textContent = `第 ${state.advanced.majorRound} 大局結果：平手 (${playerWins}:${cpuWins})`;
+    finalResult.className = "final-result draw";
+  }
 
   updateAdvancedDashboard();
   updateGuide();
-
-  const finished = finalizeAdvancedIfNeeded();
-  if (finished) return;
-
-  state.advanced.majorRound += 1;
-  hint.textContent = `進入第 ${state.advanced.majorRound} 大局：請先打完 5 回合再結算功能卡。`;
-  finalResult.textContent = `進階進行中：大局 玩家 ${state.advanced.majorScore.player} : 電腦 ${state.advanced.majorScore.cpu}`;
-  finalResult.className = "final-result";
-
-  resetRound();
   renderAdvancedCardOptions();
-  updateAdvancedDashboard();
+
+  if (advancedShouldEnd()) {
+    finalizeAdvancedMatch();
+  } else {
+    hint.textContent = "此大局結果已展示。請按「下一大局」繼續。";
+    nextMajorBtn.classList.remove("hidden");
+  }
 };
 
 const finalizeBasicGame = () => {
@@ -338,6 +425,7 @@ const finalizeBasicGame = () => {
 };
 
 const playRound = (playerValue) => {
+  if (state.mode === MODE.ADVANCED && (state.advanced.awaitingNext || state.advanced.matchFinished)) return;
   if (!state.playerDeck.includes(playerValue) || state.playerHistory.length >= TOTAL_ROUNDS) return;
 
   const roundIndex = state.playerHistory.length;
@@ -361,7 +449,7 @@ const playRound = (playerValue) => {
     if (state.mode === MODE.BASIC) {
       finalizeBasicGame();
     } else {
-      hint.textContent = "5 回合完成！請選擇功能卡與位置，按「結算本大局」。";
+      hint.textContent = "5 回合完成，請選擇功能卡與位置，執行效果並查看本大局結果。";
       resolveAdvancedBtn.disabled = false;
     }
   } else {
@@ -373,6 +461,7 @@ const resetMatch = () => {
   roundTableBody.innerHTML = "";
   finalResult.textContent = "尚未完成本局。";
   finalResult.className = "final-result";
+  nextMajorBtn.classList.add("hidden");
 
   if (state.mode === MODE.ADVANCED) {
     state.advanced.majorRound = 1;
@@ -380,7 +469,9 @@ const resetMatch = () => {
     state.advanced.minorScore = { cpu: 0, player: 0, draw: 0 };
     state.advanced.cpuCards = [...CARD_LABELS];
     state.advanced.playerCards = [...CARD_LABELS];
-    advancedStatus.textContent = "進階模式開始：每大局完成 5 回合後，再選 1 張功能卡結算。";
+    state.advanced.awaitingNext = false;
+    state.advanced.matchFinished = false;
+    advancedStatus.textContent = "進階模式開始：先完成 5 回合，再把功能卡擺放到指定位置並執行效果。";
     hint.textContent = "進階模式：先完成第 1 大局的 5 回合。";
     renderAdvancedCardOptions();
     updateAdvancedDashboard();
@@ -402,11 +493,11 @@ const setMode = (mode) => {
 
   if (isAdvanced) {
     gameTitle.textContent = "1-2-3-4-5 遊戲（進階規則）";
-    gameSubtitle.innerHTML = "三大局制，含 <strong>J / Q / K / JOKER</strong> 功能卡，平手可比小分。";
+    gameSubtitle.innerHTML = "可視化功能卡擺放：<strong>J / Q / K / JOKER</strong>，每大局執行後展示結果再決定是否進下一局。";
     rulesList.innerHTML = `
       <li>每大局先進行 5 回合出牌（不可重複）。</li>
-      <li>雙方各出 1 張功能卡並選位置，依序觸發後結算。</li>
-      <li>先到 2 勝直接獲勝；三大局同分可加開第四局，再比小分。</li>
+      <li>雙方把功能卡擺放到指定位置，再執行效果。</li>
+      <li>執行後會留在當前畫面展示結果，按「下一大局」才繼續。</li>
     `;
   } else {
     gameTitle.textContent = "1-2-3-4-5 遊戲（基本規則）";
@@ -433,6 +524,7 @@ playerArea.addEventListener("drop", (event) => {
 
 document.getElementById("restart-btn").addEventListener("click", resetMatch);
 resolveAdvancedBtn.addEventListener("click", settleAdvancedMajorRound);
+nextMajorBtn.addEventListener("click", startNextMajorRound);
 modeBasicBtn.addEventListener("click", () => setMode(MODE.BASIC));
 modeAdvancedBtn.addEventListener("click", () => setMode(MODE.ADVANCED));
 

--- a/frontend/12345.js
+++ b/frontend/12345.js
@@ -30,6 +30,8 @@ const cpuArea = document.getElementById("cpu-area");
 const playerArea = document.getElementById("player-area");
 const cpuFuncRow = document.getElementById("cpu-func-row");
 const playerFuncRow = document.getElementById("player-func-row");
+const advancedBoardTools = document.getElementById("advanced-board-tools");
+const roundOutcomeRow = document.getElementById("round-outcome-row");
 const playerHand = document.getElementById("player-hand");
 const roundTableBody = document.querySelector("#round-table tbody");
 const finalResult = document.getElementById("final-result");
@@ -103,6 +105,28 @@ const applyJoker = (playerDeck, cpuDeck) => {
   cpuDeck.splice(0, cpuDeck.length, ...playerCopy);
 };
 
+
+const resultLabel = (result) => {
+  if (result === "WIN") return "WIN";
+  if (result === "LOSE") return "LOSE";
+  return "DRAW";
+};
+
+const renderOutcomeRow = (cpuBoard, playerBoard) => {
+  roundOutcomeRow.innerHTML = "";
+  for (let i = 0; i < TOTAL_ROUNDS; i += 1) {
+    const chip = document.createElement("div");
+    chip.className = "outcome-chip";
+    if (playerBoard[i] !== undefined && cpuBoard[i] !== undefined) {
+      const r = compareCards(cpuBoard[i], playerBoard[i]);
+      chip.textContent = resultLabel(r);
+      chip.classList.add(r.toLowerCase());
+    } else {
+      chip.textContent = "-";
+    }
+    roundOutcomeRow.appendChild(chip);
+  }
+};
 const createSlot = (className = "slot") => {
   const slot = document.createElement("div");
   slot.className = className;
@@ -257,7 +281,9 @@ const resetRound = () => {
   buildSlots();
   clearFunctionPlacement();
   clearEffectPanel();
+  renderOutcomeRow([], []);
   renderPlayerHand();
+  renderOutcomeRow(state.cpuHistory, state.playerHistory);
   updateRoundProgress();
   updateGuide();
 };
@@ -418,6 +444,7 @@ const settleAdvancedMajorRound = () => {
   }
 
   renderBoardToArea(cpuBoard, playerBoard);
+  renderOutcomeRow(cpuBoard, playerBoard);
   renderEffectPanel({ logs, beforeCpuBoard, beforePlayerBoard, afterCpuBoard: cpuBoard, afterPlayerBoard: playerBoard });
 
   const { playerWins, cpuWins, draws } = countBoardResult(cpuBoard, playerBoard);
@@ -501,6 +528,7 @@ const playRound = (playerValue) => {
   renderRoundRow(state.advanced.majorRound, roundIndex, cpuValue, playerValue, roundResult);
 
   renderPlayerHand();
+  renderOutcomeRow(state.cpuHistory, state.playerHistory);
   updateRoundProgress();
   updateGuide();
 
@@ -549,6 +577,7 @@ const setMode = (mode) => {
   modeBasicBtn.classList.toggle("active", !isAdvanced);
   modeAdvancedBtn.classList.toggle("active", isAdvanced);
   advancedControls.classList.toggle("hidden", !isAdvanced);
+  advancedBoardTools.classList.toggle("hidden", !isAdvanced);
 
   if (isAdvanced) {
     gameTitle.textContent = "1-2-3-4-5 遊戲（進階規則）";

--- a/frontend/12345.js
+++ b/frontend/12345.js
@@ -1,4 +1,9 @@
 const TOTAL_ROUNDS = 5;
+const MODE = {
+  BASIC: "basic",
+  ADVANCED: "advanced",
+};
+const CARD_LABELS = ["J", "Q", "K", "JK"];
 
 const integrations = {
   onRoundComplete: (_payload) => {},
@@ -6,6 +11,7 @@ const integrations = {
 };
 
 const state = {
+  mode: MODE.BASIC,
   cpuDeck: [],
   playerDeck: [1, 2, 3, 4, 5],
   cpuHistory: [],
@@ -13,6 +19,13 @@ const state = {
   scoreboard: {
     cpu: { win: 0, lose: 0, draw: 0 },
     player: { win: 0, lose: 0, draw: 0 },
+  },
+  advanced: {
+    majorRound: 1,
+    majorScore: { cpu: 0, player: 0, draw: 0 },
+    minorScore: { cpu: 0, player: 0, draw: 0 },
+    cpuCards: [...CARD_LABELS],
+    playerCards: [...CARD_LABELS],
   },
 };
 
@@ -22,6 +35,16 @@ const playerHand = document.getElementById("player-hand");
 const roundTableBody = document.querySelector("#round-table tbody");
 const finalResult = document.getElementById("final-result");
 const hint = document.getElementById("hint");
+const gameTitle = document.getElementById("game-title");
+const gameSubtitle = document.getElementById("game-subtitle");
+const rulesList = document.getElementById("rules-list");
+const advancedControls = document.getElementById("advanced-controls");
+const advancedStatus = document.getElementById("advanced-status");
+const playerCardSelect = document.getElementById("player-card-select");
+const playerPosSelect = document.getElementById("player-pos-select");
+const resolveAdvancedBtn = document.getElementById("resolve-advanced-btn");
+const modeBasicBtn = document.getElementById("mode-basic");
+const modeAdvancedBtn = document.getElementById("mode-advanced");
 
 const shuffle = (list) => {
   const arr = [...list];
@@ -37,6 +60,29 @@ const compareCards = (cpu, player) => {
   if ((player === 1 && cpu === 5) || (player === 2 && cpu === 4)) return "WIN";
   if ((cpu === 1 && player === 5) || (cpu === 2 && player === 4)) return "LOSE";
   return player > cpu ? "WIN" : "LOSE";
+};
+
+const applyJQ = (deck, card, pos) => {
+  const i = pos - 1;
+  if (card === "J") {
+    const target = i === 0 ? deck.length - 1 : i - 1;
+    [deck[i], deck[target]] = [deck[target], deck[i]];
+  }
+  if (card === "Q") {
+    const target = i === deck.length - 1 ? 0 : i + 1;
+    [deck[i], deck[target]] = [deck[target], deck[i]];
+  }
+};
+
+const applyK = (playerDeck, cpuDeck, pos) => {
+  const i = pos - 1;
+  [playerDeck[i], cpuDeck[i]] = [cpuDeck[i], playerDeck[i]];
+};
+
+const applyJoker = (playerDeck, cpuDeck) => {
+  const playerCopy = [...playerDeck];
+  playerDeck.splice(0, playerDeck.length, ...cpuDeck);
+  cpuDeck.splice(0, cpuDeck.length, ...playerCopy);
 };
 
 const createSlot = () => {
@@ -87,10 +133,10 @@ const pushCardToArea = (area, value, roundIndex) => {
   slots[roundIndex].textContent = value;
 };
 
-const renderRoundRow = (roundIndex, cpuValue, playerValue, result) => {
+const renderRoundRow = (majorRound, roundIndex, cpuValue, playerValue, result) => {
   const tr = document.createElement("tr");
   tr.innerHTML = `
-    <td>${roundIndex + 1}</td>
+    <td>${state.mode === MODE.ADVANCED ? `${majorRound}-${roundIndex + 1}` : roundIndex + 1}</td>
     <td>${cpuValue}</td>
     <td>${playerValue}</td>
     <td>${result}</td>
@@ -98,7 +144,114 @@ const renderRoundRow = (roundIndex, cpuValue, playerValue, result) => {
   roundTableBody.appendChild(tr);
 };
 
-const finalizeGame = () => {
+const resetRound = () => {
+  state.cpuDeck = shuffle([1, 2, 3, 4, 5]);
+  state.playerDeck = [1, 2, 3, 4, 5];
+  state.cpuHistory = [];
+  state.playerHistory = [];
+  buildSlots();
+  renderPlayerHand();
+};
+
+const renderAdvancedCardOptions = () => {
+  playerCardSelect.innerHTML = "";
+  state.advanced.playerCards.forEach((card) => {
+    const option = document.createElement("option");
+    option.value = card;
+    option.textContent = card === "JK" ? "JOKER" : card;
+    playerCardSelect.appendChild(option);
+  });
+};
+
+const settleAdvancedMajorRound = () => {
+  if (state.playerHistory.length < TOTAL_ROUNDS) return;
+  const playerCard = playerCardSelect.value;
+  const playerPos = Number(playerPosSelect.value);
+  if (!state.advanced.playerCards.includes(playerCard)) return;
+
+  const cpuCard = state.advanced.cpuCards[Math.floor(Math.random() * state.advanced.cpuCards.length)];
+  const cpuPos = Math.floor(Math.random() * 5) + 1;
+
+  const playerBoard = [...state.playerHistory];
+  const cpuBoard = [...state.cpuHistory];
+
+  if (playerCard === "J" || playerCard === "Q") applyJQ(playerBoard, playerCard, playerPos);
+  if (cpuCard === "J" || cpuCard === "Q") applyJQ(cpuBoard, cpuCard, cpuPos);
+  if (playerCard === "K") applyK(playerBoard, cpuBoard, playerPos);
+  if (cpuCard === "K") applyK(playerBoard, cpuBoard, cpuPos);
+  if (playerCard === "JK") applyJoker(playerBoard, cpuBoard);
+  if (cpuCard === "JK") applyJoker(playerBoard, cpuBoard);
+
+  let playerWins = 0;
+  let cpuWins = 0;
+  let draws = 0;
+  for (let i = 0; i < 5; i += 1) {
+    const result = compareCards(cpuBoard[i], playerBoard[i]);
+    if (result === "WIN") playerWins += 1;
+    if (result === "LOSE") cpuWins += 1;
+    if (result === "DRAW") draws += 1;
+  }
+
+  state.advanced.minorScore.player += playerWins;
+  state.advanced.minorScore.cpu += cpuWins;
+  state.advanced.minorScore.draw += draws;
+
+  if (playerWins > cpuWins) state.advanced.majorScore.player += 1;
+  else if (playerWins < cpuWins) state.advanced.majorScore.cpu += 1;
+  else state.advanced.majorScore.draw += 1;
+
+  state.advanced.playerCards = state.advanced.playerCards.filter((c) => c !== playerCard);
+  state.advanced.cpuCards = state.advanced.cpuCards.filter((c) => c !== cpuCard);
+
+  advancedStatus.textContent = `第 ${state.advanced.majorRound} 大局：玩家 ${playerCard}(${playerPos}) / 電腦 ${cpuCard}(${cpuPos})，小局 ${playerWins}:${cpuWins}`;
+
+  const isAfterThird = state.advanced.majorRound >= 3;
+  const major = state.advanced.majorScore;
+  const doneByScore = major.player >= 2 || major.cpu >= 2;
+  const tieNeedFourth = isAfterThird && major.player === major.cpu;
+
+  if (doneByScore || (isAfterThird && !tieNeedFourth) || state.advanced.majorRound === 4) {
+    if (major.player > major.cpu) {
+      finalResult.textContent = `進階模式結束：玩家勝利（大局 ${major.player}:${major.cpu}）`;
+      finalResult.className = "final-result win";
+      state.scoreboard.player.win += 1;
+      state.scoreboard.cpu.lose += 1;
+    } else if (major.player < major.cpu) {
+      finalResult.textContent = `進階模式結束：電腦勝利（大局 ${major.cpu}:${major.player}）`;
+      finalResult.className = "final-result lose";
+      state.scoreboard.player.lose += 1;
+      state.scoreboard.cpu.win += 1;
+    } else if (state.advanced.minorScore.player > state.advanced.minorScore.cpu) {
+      finalResult.textContent = `進階模式結束：玩家以小分勝（${state.advanced.minorScore.player}:${state.advanced.minorScore.cpu}）`;
+      finalResult.className = "final-result win";
+      state.scoreboard.player.win += 1;
+      state.scoreboard.cpu.lose += 1;
+    } else if (state.advanced.minorScore.player < state.advanced.minorScore.cpu) {
+      finalResult.textContent = `進階模式結束：電腦以小分勝（${state.advanced.minorScore.cpu}:${state.advanced.minorScore.player}）`;
+      finalResult.className = "final-result lose";
+      state.scoreboard.player.lose += 1;
+      state.scoreboard.cpu.win += 1;
+    } else {
+      finalResult.textContent = "進階模式結束：完全平手";
+      finalResult.className = "final-result draw";
+      state.scoreboard.player.draw += 1;
+      state.scoreboard.cpu.draw += 1;
+    }
+    hint.textContent = "本局已完成，點擊 Restart 開始下一局。";
+    updateScoreboardView();
+    integrations.onMatchComplete({ ...state.advanced });
+    return;
+  }
+
+  state.advanced.majorRound += 1;
+  hint.textContent = `進入第 ${state.advanced.majorRound} 大局，請完成 5 回合出牌。`;
+  finalResult.textContent = `進階進行中：大局 玩家 ${major.player} : 電腦 ${major.cpu}`;
+  finalResult.className = "final-result";
+  resetRound();
+  renderAdvancedCardOptions();
+};
+
+const finalizeBasicGame = () => {
   const wins = state.playerHistory.filter((_, i) => compareCards(state.cpuHistory[i], state.playerHistory[i]) === "WIN").length;
   const loses = state.playerHistory.filter((_, i) => compareCards(state.cpuHistory[i], state.playerHistory[i]) === "LOSE").length;
 
@@ -145,7 +298,7 @@ const playRound = (playerValue) => {
   pushCardToArea(playerArea, playerValue, roundIndex);
 
   const roundResult = compareCards(cpuValue, playerValue);
-  renderRoundRow(roundIndex, cpuValue, playerValue, roundResult);
+  renderRoundRow(state.advanced.majorRound, roundIndex, cpuValue, playerValue, roundResult);
 
   integrations.onRoundComplete({
     round: roundIndex + 1,
@@ -157,25 +310,64 @@ const playRound = (playerValue) => {
   renderPlayerHand();
 
   if (state.playerHistory.length === TOTAL_ROUNDS) {
-    finalizeGame();
+    if (state.mode === MODE.BASIC) {
+      finalizeBasicGame();
+    } else {
+      hint.textContent = "已完成 5 回合，請選擇功能卡與位置後按下「結算本大局」。";
+    }
   } else {
     hint.textContent = `已完成第 ${state.playerHistory.length} 回合，請繼續出牌。`;
   }
 };
 
 const resetMatch = () => {
-  state.cpuDeck = shuffle([1, 2, 3, 4, 5]);
-  state.playerDeck = [1, 2, 3, 4, 5];
-  state.cpuHistory = [];
-  state.playerHistory = [];
-
   roundTableBody.innerHTML = "";
   finalResult.textContent = "尚未完成本局。";
   finalResult.className = "final-result";
-  hint.textContent = "拖曳或點擊下方玩家卡牌開始出牌。";
 
-  buildSlots();
-  renderPlayerHand();
+  if (state.mode === MODE.ADVANCED) {
+    state.advanced.majorRound = 1;
+    state.advanced.majorScore = { cpu: 0, player: 0, draw: 0 };
+    state.advanced.minorScore = { cpu: 0, player: 0, draw: 0 };
+    state.advanced.cpuCards = [...CARD_LABELS];
+    state.advanced.playerCards = [...CARD_LABELS];
+    renderAdvancedCardOptions();
+    advancedStatus.textContent = "每大局可選 1 張功能卡，四張卡整場各只能用一次。";
+    hint.textContent = "進階模式：先完成第 1 大局的 5 回合，再結算功能卡。";
+  } else {
+    hint.textContent = "拖曳或點擊下方玩家卡牌開始出牌。";
+    advancedStatus.textContent = "";
+  }
+
+  resetRound();
+};
+
+const setMode = (mode) => {
+  state.mode = mode;
+  const isAdvanced = mode === MODE.ADVANCED;
+  modeBasicBtn.classList.toggle("active", !isAdvanced);
+  modeAdvancedBtn.classList.toggle("active", isAdvanced);
+  advancedControls.classList.toggle("hidden", !isAdvanced);
+
+  if (isAdvanced) {
+    gameTitle.textContent = "1-2-3-4-5 遊戲（進階規則）";
+    gameSubtitle.innerHTML = "三大局制，含 <strong>J / Q / K / JOKER</strong> 功能卡；同分可比小分。";
+    rulesList.innerHTML = `
+      <li>每大局先進行 5 回合出牌（不可重複）。</li>
+      <li>再選 1 張功能卡與位置，依序觸發後結算大局。</li>
+      <li>共三大局；若同分可加開第四局並比較小分。</li>
+    `;
+  } else {
+    gameTitle.textContent = "1-2-3-4-5 遊戲（基本規則）";
+    gameSubtitle.innerHTML = "大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。";
+    rulesList.innerHTML = `
+      <li>每回合從玩家手牌出 1 張。</li>
+      <li>共 5 回合，系統會顯示 WIN / LOSE / DRAW。</li>
+      <li>按 Restart 可快速再開一局。</li>
+    `;
+  }
+
+  resetMatch();
 };
 
 playerArea.addEventListener("dragover", (event) => {
@@ -189,6 +381,9 @@ playerArea.addEventListener("drop", (event) => {
 });
 
 document.getElementById("restart-btn").addEventListener("click", resetMatch);
+resolveAdvancedBtn.addEventListener("click", settleAdvancedMajorRound);
+modeBasicBtn.addEventListener("click", () => setMode(MODE.BASIC));
+modeAdvancedBtn.addEventListener("click", () => setMode(MODE.ADVANCED));
 
-resetMatch();
+setMode(MODE.BASIC);
 updateScoreboardView();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,8 +12,12 @@
   <main class="layout">
     <section class="game-shell panel">
       <header class="game-header">
-        <h1>1-2-3-4-5 遊戲（基本規則）</h1>
-        <p class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+        <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
+        <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+        <div class="mode-switch" role="group" aria-label="模式切換">
+          <button id="mode-basic" class="button mode active" type="button">普通模式</button>
+          <button id="mode-advanced" class="button mode" type="button">進階模式</button>
+        </div>
       </header>
 
       <section class="battlefield">
@@ -31,12 +35,34 @@
         <p id="hint" class="hint">拖曳或點擊下方玩家卡牌開始出牌。</p>
         <button id="restart-btn" class="button" type="button">Restart</button>
       </footer>
+
+      <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
+        <h3>進階功能卡操作</h3>
+        <div class="advanced-grid">
+          <div>
+            <label for="player-card-select">玩家功能卡</label>
+            <select id="player-card-select"></select>
+          </div>
+          <div>
+            <label for="player-pos-select">放置位置</label>
+            <select id="player-pos-select">
+              <option value="1">位置 1</option>
+              <option value="2">位置 2</option>
+              <option value="3">位置 3</option>
+              <option value="4">位置 4</option>
+              <option value="5">位置 5</option>
+            </select>
+          </div>
+          <button id="resolve-advanced-btn" class="button" type="button">結算本大局</button>
+        </div>
+        <p id="advanced-status" class="hint"></p>
+      </section>
     </section>
 
     <aside class="side-panels">
       <details class="panel fold" open>
         <summary>遊戲方法與提示</summary>
-        <ol>
+        <ol id="rules-list">
           <li>每回合從玩家手牌出 1 張。</li>
           <li>共 5 回合，系統會顯示 WIN / LOSE / DRAW。</li>
           <li>按 Restart 可快速再開一局。</li>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,11 +35,21 @@
         </div>
         <div id="cpu-area" class="slots"></div>
 
+        <div class="func-row-wrap">
+          <span class="func-label">電腦功能卡擺放</span>
+          <div id="cpu-func-row" class="func-row"></div>
+        </div>
+
         <h2 class="mid-title">出牌區</h2>
         <div id="player-area" class="slots drop-target" aria-label="玩家置牌區"></div>
 
         <h2>玩家手牌</h2>
         <div id="player-hand" class="hand"></div>
+
+        <div class="func-row-wrap">
+          <span class="func-label">玩家功能卡擺放</span>
+          <div id="player-func-row" class="func-row"></div>
+        </div>
       </section>
 
       <footer class="action-row">
@@ -72,7 +82,8 @@
               <option value="5">位置 5</option>
             </select>
           </div>
-          <button id="resolve-advanced-btn" class="button" type="button" disabled>結算本大局</button>
+          <button id="resolve-advanced-btn" class="button" type="button" disabled>執行功能卡效果</button>
+          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
         </div>
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,9 +35,16 @@
         </div>
         <div id="cpu-area" class="slots"></div>
 
-        <div class="func-row-wrap">
-          <span class="func-label">電腦功能卡擺放</span>
-          <div id="cpu-func-row" class="func-row"></div>
+        <div id="advanced-board-tools" class="advanced-only hidden">
+          <div class="func-row-wrap">
+            <span class="func-label">電腦功能卡擺放</span>
+            <div id="cpu-func-row" class="func-row"></div>
+          </div>
+
+          <div class="func-row-wrap">
+            <span class="func-label">玩家功能卡擺放</span>
+            <div id="player-func-row" class="func-row"></div>
+          </div>
         </div>
 
         <h2 class="mid-title">出牌區</h2>
@@ -46,15 +53,18 @@
         <h2>玩家手牌</h2>
         <div id="player-hand" class="hand"></div>
 
-        <div class="func-row-wrap">
-          <span class="func-label">玩家功能卡擺放</span>
-          <div id="player-func-row" class="func-row"></div>
+        <div class="outcome-wrap">
+          <span class="func-label">玩家每回合結果（主戰場直觀顯示）</span>
+          <div id="round-outcome-row" class="outcome-row"></div>
         </div>
       </section>
 
       <footer class="action-row">
         <p id="hint" class="hint">拖曳或點擊下方玩家卡牌開始出牌。</p>
-        <button id="restart-btn" class="button" type="button">Restart</button>
+        <div class="action-buttons">
+          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
+          <button id="restart-btn" class="button" type="button">Restart</button>
+        </div>
       </footer>
 
       <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
@@ -83,7 +93,6 @@
             </select>
           </div>
           <button id="resolve-advanced-btn" class="button" type="button" disabled>執行功能卡效果</button>
-          <button id="next-major-btn" class="button ghost hidden" type="button">下一大局</button>
         </div>
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,8 @@
 <body>
   <main class="layout">
     <section class="game-shell panel">
-      <header class="game-header">
+      <header class="game-header modern-hero">
+        <p class="eyebrow">ONE-TWO-FIVE • STRATEGY CARD GAME</p>
         <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
         <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -88,6 +88,24 @@
 
         <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>
         <p id="advanced-status" class="hint"></p>
+
+        <div class="effect-panel">
+          <div class="effect-block">
+            <h4>效果流程</h4>
+            <ol id="effect-log" class="effect-log">
+              <li>尚未執行功能卡效果。</li>
+            </ol>
+          </div>
+          <div class="effect-block">
+            <h4>盤面前後對照</h4>
+            <p class="mini-label">效果前（電腦 / 玩家）</p>
+            <div id="before-cpu" class="mini-row"></div>
+            <div id="before-player" class="mini-row"></div>
+            <p class="mini-label">效果後（電腦 / 玩家）</p>
+            <div id="after-cpu" class="mini-row"></div>
+            <div id="after-player" class="mini-row"></div>
+          </div>
+        </div>
       </section>
     </section>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,14 +14,24 @@
       <header class="game-header">
         <h1 id="game-title">1-2-3-4-5 遊戲（基本規則）</h1>
         <p id="game-subtitle" class="subtitle">大數字勝，例外：<strong>1 勝 5、2 勝 4</strong>。每張牌只能出一次。</p>
+
         <div class="mode-switch" role="group" aria-label="模式切換">
           <button id="mode-basic" class="button mode active" type="button">普通模式</button>
           <button id="mode-advanced" class="button mode" type="button">進階模式</button>
         </div>
+
+        <div class="guide-strip" aria-live="polite">
+          <span id="step-choose-mode" class="guide-step active">1. 選模式</span>
+          <span id="step-play-five" class="guide-step">2. 出完 5 張牌</span>
+          <span id="step-resolve-card" class="guide-step">3.（進階）結算功能卡</span>
+        </div>
       </header>
 
       <section class="battlefield">
-        <h2>電腦手牌</h2>
+        <div class="row-title">
+          <h2>電腦手牌</h2>
+          <span id="round-progress" class="pill">回合 0 / 5</span>
+        </div>
         <div id="cpu-area" class="slots"></div>
 
         <h2 class="mid-title">出牌區</h2>
@@ -37,10 +47,18 @@
       </footer>
 
       <section id="advanced-controls" class="panel advanced-controls hidden" aria-live="polite">
-        <h3>進階功能卡操作</h3>
+        <div class="advanced-top">
+          <h3>進階功能卡結算</h3>
+          <div class="advanced-stats">
+            <span id="major-round-pill" class="pill">大局 1 / 3+</span>
+            <span id="major-score-pill" class="pill">大局比數 玩家 0 : 0 電腦</span>
+            <span id="minor-score-pill" class="pill">小分 玩家 0 : 0 電腦</span>
+          </div>
+        </div>
+
         <div class="advanced-grid">
           <div>
-            <label for="player-card-select">玩家功能卡</label>
+            <label for="player-card-select">玩家功能卡（每張整場僅一次）</label>
             <select id="player-card-select"></select>
           </div>
           <div>
@@ -53,8 +71,10 @@
               <option value="5">位置 5</option>
             </select>
           </div>
-          <button id="resolve-advanced-btn" class="button" type="button">結算本大局</button>
+          <button id="resolve-advanced-btn" class="button" type="button" disabled>結算本大局</button>
         </div>
+
+        <p id="cards-left" class="hint">剩餘功能卡：J, Q, K, JOKER</p>
         <p id="advanced-status" class="hint"></p>
       </section>
     </section>
@@ -67,6 +87,17 @@
           <li>共 5 回合，系統會顯示 WIN / LOSE / DRAW。</li>
           <li>按 Restart 可快速再開一局。</li>
         </ol>
+      </details>
+
+      <details class="panel fold" open>
+        <summary>功能卡速查（進階）</summary>
+        <ul class="card-guide">
+          <li><strong>J</strong>：指定位置與左邊交換（位置1會和位置5交換）</li>
+          <li><strong>Q</strong>：指定位置與右邊交換（位置5會和位置1交換）</li>
+          <li><strong>K</strong>：指定位置與對手同位置交換</li>
+          <li><strong>JOKER</strong>：雙方整個盤面互換</li>
+        </ul>
+        <p class="hint">觸發順序：J/Q → K → JOKER（玩家先觸發）</p>
       </details>
 
       <details class="panel fold" open>


### PR DESCRIPTION
### Motivation
- Provide a single-page frontend that supports both the existing basic game and the new advanced rules so players can switch modes without conflicting pages. 
- Expose the advanced-rule mechanics (J / Q / K / JOKER) in the UI so non-console users can play the three-major-round advanced flow in-browser. 

### Description
- Added a mode switch UI (`普通模式` / `進階模式`) and dynamic title/rules text to `frontend/12345.html` and synced `frontend/index.html`. 
- Implemented an advanced-controls panel with card selection, position selector and a `結算本大局` button, and associated styles in `frontend/12345.css`. 
- Implemented the advanced-rule client logic in `frontend/12345.js`, including `state.advanced`, `applyJQ`, `applyK`, `applyJoker`, `settleAdvancedMajorRound`, per-major-round bookkeeping (major/minor scores), card-use tracking and mode-aware rendering; the basic flow is preserved and mode selection toggles behavior. 
- Updated layout/CSS for mode buttons and responsive advanced controls and kept backward-compatible basic-mode behavior. 

### Testing
- Static syntax check with `node --check frontend/12345.js` which completed successfully. 
- Launched a local static server with `python -m http.server 4173 --directory frontend` and exercised the UI with a Playwright script that opened `http://127.0.0.1:4173/12345.html`, clicked the `進階模式` button and captured a screenshot; the script ran and produced a screenshot artifact proving the advanced UI appears. 
- Manually exercised flows in the served page to verify mode switching, completing 5 rounds and resolving an advanced major round; these checks succeeded (UI shows updated titles, rules and results).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6764178008322b96bceb8fc0c2fba)